### PR TITLE
Fix double forward slash causing NOT FOUND error

### DIFF
--- a/clipping_manager/templates/clipping_manager/dashboard.html
+++ b/clipping_manager/templates/clipping_manager/dashboard.html
@@ -94,7 +94,7 @@
 
                     <ol>
                         <li>Import your clippings&nbsp;<a
-                                href="{% url 'clipping_manager:upload' %}/" class="btn btn-text">here</a></li>
+                                href="{% url 'clipping_manager:upload' %}" class="btn btn-text">here</a></li>
                         <li>Install a browser extension like for example&nbsp;<a
                                 href="https://chrome.google.com/webstore/detail/new-tab-url/njigpponciklokfkoddampoienefegcl/related?hl=en"
                                 target="_blank">New Tab URL</a></li>


### PR DESCRIPTION
Fixes https://github.com/mammuth/kindle-clippings/issues/18

PR https://github.com/mammuth/kindle-clippings/pull/22 addressed the first half of the issue. This PR should address the second part which is a broken link caused by double forward slashes.

![image](https://user-images.githubusercontent.com/6220504/115057429-f4fa4180-9edb-11eb-81b2-277a38a4b533.png)

----
On a personal note - I just came across this project after wanting a service just like this. Having not found anything that exactly suited my needs (and without having an ongoing subscription) I was going to build something myself - then came across this. The interface is great -well done. Looking forward to receiving my first email tomorrow!